### PR TITLE
Do not format ruby code in erb-formatter

### DIFF
--- a/erb-formatter.gemspec
+++ b/erb-formatter.gemspec
@@ -28,8 +28,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "syntax_tree", '~> 6.0'
-
   spec.add_development_dependency "tailwindcss-rails", "~> 2.0"
   spec.add_development_dependency "m", "~> 1.0"
 end

--- a/lib/erb/formatter.rb
+++ b/lib/erb/formatter.rb
@@ -8,20 +8,7 @@ require 'stringio'
 require 'securerandom'
 require 'erb/formatter/version'
 
-require 'syntax_tree'
-require 'syntax_tree/plugin/trailing_comma'
-
 class ERB::Formatter
-  module SyntaxTreeCommandPatch
-    def format(q)
-      q.group do
-        q.format(message)
-        q.text(" ")
-        q.format(arguments) # WAS: q.nest(message.value.length + 1) { q.format(arguments) }
-      end
-    end
-  end
-
   autoload :IgnoreList, 'erb/formatter/ignore_list'
 
   class Error < StandardError; end
@@ -265,21 +252,6 @@ class ERB::Formatter
       code += "\nend" unless RUBY_OPEN_BLOCK["#{code}\nend"]
       code += "\n}" unless RUBY_OPEN_BLOCK["#{code}\n}"]
     end
-    p RUBY_IN_: code if @debug
-
-    SyntaxTree::Command.prepend SyntaxTreeCommandPatch
-
-    code = begin
-      SyntaxTree.format(code, @line_width)
-    rescue SyntaxTree::Parser::ParseError => error
-      p RUBY_PARSE_ERROR: error if @debug
-      code
-    end
-
-    lines = code.strip.lines
-    lines = lines[0...-1] if autoclose
-    code = lines.map { |l| indented(l.chomp("\n"), strip: false) }.join.strip
-    p RUBY_OUT: code if @debug
     code
   end
 


### PR DESCRIPTION
`erb-formatter` uses the `syntax_tree` gem which has its own formatting ideas about ruby, but, in our code base, so does Rubocop, the latter which we configure extensively.  When they disagree, the result is flip-flopping between tools, and that can fail the clover build, in this CI step in `.github/workflows/ci.yml`:

    - name: Check that source code formatters and annotations make no changes
      run: git diff --stat --exit-code

This was motivated by an attempt to this `.rubocop.yml` configuration in clover:

    Layout/DotPosition:
      EnforcedStyle: trailing

In this case, Rubocop moves method-chained periods to the ends of lines, and then `erb-formatter` moves them back to the beginning again.  This fails CI.

Given our more extensive rubocop use, and use of the `rubocop-erb` as we also use it for rewriting, it's simpler to remove `syntax_tree` as a dependency altogether, and not attempt to format code in `erb-formatter`.  This keeps `erb-formatter` the rest of its functionality, such as tag indentation.